### PR TITLE
enter method: pressing enter after typing text

### DIFF
--- a/lib/sikuli/typeable.rb
+++ b/lib/sikuli/typeable.rb
@@ -19,5 +19,14 @@ module Sikuli
     def type(text, modifier = 0)
       @java_obj.type(nil, text, modifier)
     end
+
+    # Public: Types text then presses the return/enter key on the keyboard
+    #
+    # text - String
+    #
+    # Returns nothing
+    def enter(text)
+      @java_obj.type(text + Sikuli::KEY_RETURN)
+    end
   end
 end


### PR DESCRIPTION
Since user will probably be entering commands a lot, I thought this was an easier way to do it instead of using the `type` method.
